### PR TITLE
Removed unused log4j dependency

### DIFF
--- a/lumino-explorer-api/pom.xml
+++ b/lumino-explorer-api/pom.xml
@@ -59,11 +59,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
         </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>


### PR DESCRIPTION
Removed unused log4j dependency. The project uses the spring default slf4j implementation.

Also, log4j has vulnerabilities: https://github.com/advisories/GHSA-2qrg-x229-3v8q

So, if we use log4j in a future, lets use the 2.0 version