### PR TITLE
Feature/rifex-152/load-balancing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,13 @@ jobs:
       - run:
           name: Build & Test Explorer Web
           command: |
-                    cd /lumino-explorer/lumino-explorer-web
+                    ls
+                    cd /home/circleci/tmp/lumino-explorer/lumino-explorer-web
                     npm install
                     npm test
       - run:
           name: Build & Test Explorer API
           command: |
-                    cd /lumino-explorer/lumino-explorer-api
+                    cd /home/circleci/tmp/lumino-explorer/lumino-explorer-web
                     mvn install
                     mvn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,15 +10,15 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Build & Test Explorer API
+          command: |
+                    cd lumino-explorer-api
+                    mvn install
+                    mvn test
+      - run:
           name: Build & Test Explorer Web
           command: |
                     cd lumino-explorer-web
                     npm install
                     npm test
-      - run:
-          name: Build & Test Explorer API
-          command: |
-                    ls
-                    cd lumino-explorer-api
-                    mvn install
-                    mvn test
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7
+    
+    working_directory: ~/tmp
+
+    steps:
+      - checkout
+      - run:
+          name: Build & Test Explorer Web
+          command: |
+                    cd /lumino-explorer/lumino-explorer-web
+                    npm install
+                    npm test
+      - run:
+          name: Build & Test Explorer API
+          command: |
+                    cd /lumino-explorer/lumino-explorer-api
+                    mvn install
+                    mvn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7
+      - image: circleci/openjdk:8-jdk
     
     working_directory: ~/tmp
 
@@ -15,6 +15,16 @@ jobs:
                     cd lumino-explorer-api
                     mvn install
                     mvn test
+      
+      - run:
+          name: Prepare npm
+          command: |
+                    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+                    sudo apt update
+                    sudo apt-get install -y nodejs
+                    sudo apt install npm
+                    sudo apt install build-essential
+      
       - run:
           name: Build & Test Explorer Web
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ jobs:
       - run:
           name: Build & Test Explorer Web
           command: |
-                    ls
-                    cd /home/circleci/tmp/lumino-explorer/lumino-explorer-web
+                    cd lumino-explorer-web
                     npm install
                     npm test
       - run:
           name: Build & Test Explorer API
           command: |
-                    cd /home/circleci/tmp/lumino-explorer/lumino-explorer-web
+                    ls
+                    cd lumino-explorer-api
                     mvn install
                     mvn test

--- a/lumino-explorer-api/README.md
+++ b/lumino-explorer-api/README.md
@@ -73,6 +73,20 @@ Bye
 ```
 
  3. Now you can check if api is running, going to http://localhost:8080. This is a default host and port if you run it locally.
+## Trusted Hub nodes
+In order to set up the load balancing endpoint, 
+you first need to configure a list of trusted Hub Nodes.
+
+In order to set a new Hub as trusted, add
+the following property (e.g. to the application.properties file):  
+``` lumino.explorer.hub.urls.$id = $url ``` 
+where **$id** is an arbitrary identifier for the node, and **$url** is its url. 
+
+There is also another property (`lumino.explorer.hub.maxConnections`)
+which sets the maximum amount of connections allowed per Hub.
+
+## API Documentation
+* [REST API Documentation](docs/api/v1/index.md)
 
 ## Additional help
 
@@ -106,9 +120,7 @@ Java home: $JAVA_HOME
 Default locale: $YOUR_LOCALE
 OS name: $YOUR_OS_VERSION
 ```
-
 ## Useful Links
-
 * [RIF Lumino Network documentation](https://www.rifos.org/rif-lumino-network/)
 * [http://explorer.lumino.rifos.org/]()
 * [RIF Lumino Contracts](https://github.com/rsksmart/lumino-contracts) 

--- a/lumino-explorer-api/docs/api/v1/index.md
+++ b/lumino-explorer-api/docs/api/v1/index.md
@@ -1,0 +1,3 @@
+## REST API Version 1
+### API Resources   
+- [Lumino Hub Connection](luminoHubConnection.md)  

--- a/lumino-explorer-api/docs/api/v1/luminoHubConnection.md
+++ b/lumino-explorer-api/docs/api/v1/luminoHubConnection.md
@@ -1,0 +1,17 @@
+## Lumino Hub Connection
+This resource holds the connection count of the
+trusted Hub nodes.
+
+
+### Endpoints   
+#### ```POST /luminoHubConnection ```  
+This endpoint adds a new connection to the hub 
+with the minimum number of connections, increases the count by 1 
+and returns the Hub's url.
+
+- **returns:**
+   * **200 OK**: If there is at least on Hub with available connections.  
+   Body:  
+   ``` { "url": "Hub's url" } ```
+   * **404 NOT FOUND**: If there isn't any registered Hub.
+   * **409 CONFLICT**: If there isn't a Hub with available connections. 

--- a/lumino-explorer-api/pom.xml
+++ b/lumino-explorer-api/pom.xml
@@ -71,6 +71,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Documentation -->
 

--- a/lumino-explorer-api/pom.xml
+++ b/lumino-explorer-api/pom.xml
@@ -59,11 +59,7 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
         </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>

--- a/lumino-explorer-api/pom.xml
+++ b/lumino-explorer-api/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
 
         <!-- Documentation -->
@@ -88,7 +93,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
 
     </dependencies>
     <properties>

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/Application.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/Application.java
@@ -7,6 +7,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -23,6 +25,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
       WebConfiguration.class,
     })
 @PropertySource(ignoreResourceNotFound = true, value = "classpath:application.properties")
+@EnableConfigurationProperties
 public class Application extends SpringBootServletInitializer {
 
   @Override

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/Application.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/Application.java
@@ -28,6 +28,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableConfigurationProperties
 public class Application extends SpringBootServletInitializer {
 
+
   @Override
   protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
     return application.sources(Application.class);

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/boot/configuration/properties/LuminoHubProperties.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/boot/configuration/properties/LuminoHubProperties.java
@@ -3,7 +3,6 @@ package org.rif.lumino.explorer.boot.configuration.properties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
 import java.util.Map;
 
 @ConfigurationProperties("lumino.explorer.hub")
@@ -12,13 +11,13 @@ public class LuminoHubProperties {
 
     private Integer maxConnections;
 
-    private List<String> urls;
+    private Map<String, String> urls;
 
-    public List<String> getUrls() {
+    public Map<String, String> getUrls() {
         return urls;
     }
 
-    public void setUrls(List<String> urls) {
+    public void setUrls(Map<String, String> urls) {
         this.urls = urls;
     }
 

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/boot/configuration/properties/LuminoHubProperties.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/boot/configuration/properties/LuminoHubProperties.java
@@ -1,0 +1,32 @@
+package org.rif.lumino.explorer.boot.configuration.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+@ConfigurationProperties("lumino.explorer.hub")
+@Configuration
+public class LuminoHubProperties {
+
+    private Integer maxConnections;
+
+    private List<String> urls;
+
+    public List<String> getUrls() {
+        return urls;
+    }
+
+    public void setUrls(List<String> urls) {
+        this.urls = urls;
+    }
+
+    public Integer getMaxConnections() {
+        return maxConnections;
+    }
+
+    public void setMaxConnections(Integer maxConnections) {
+        this.maxConnections = maxConnections;
+    }
+}

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/controllers/LuminoHubConnectionController.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/controllers/LuminoHubConnectionController.java
@@ -1,0 +1,42 @@
+package org.rif.lumino.explorer.controllers;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.rif.lumino.explorer.constants.ControllerConstants;
+import org.rif.lumino.explorer.exceptions.MaxConnectionException;
+import org.rif.lumino.explorer.exceptions.NotFoundException;
+import org.rif.lumino.explorer.managers.LuminoHubManager;
+import org.rif.lumino.explorer.models.dto.LuminoHubDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = {"Lumino Hub Connection Resource"})
+@RestController
+@RequestMapping(ControllerConstants.API_V1_VERSION_PATH + "/luminoHubConnection")
+public class LuminoHubConnectionController {
+
+    @Autowired
+    private LuminoHubManager luminoHubManager;
+
+    @ApiOperation(value = "Register a new intent to connect to a Lumino Hub, and returns the url of the most appropriate one")
+    @PostMapping
+    public ResponseEntity<LuminoHubDTO> register() {
+        String hubUrl = luminoHubManager.addConnectionAndGetUrl();
+        return ResponseEntity.accepted().body(new LuminoHubDTO(hubUrl));
+    }
+
+    @ExceptionHandler(MaxConnectionException.class)
+    public ResponseEntity<Void> handle(MaxConnectionException e) {
+        return ResponseEntity.unprocessableEntity().build();
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Void> handle(NotFoundException e) {
+        return ResponseEntity.notFound().build();
+    }
+
+}

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/controllers/LuminoHubConnectionController.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/controllers/LuminoHubConnectionController.java
@@ -8,6 +8,7 @@ import org.rif.lumino.explorer.exceptions.NotFoundException;
 import org.rif.lumino.explorer.managers.LuminoHubManager;
 import org.rif.lumino.explorer.models.dto.LuminoHubDTO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,8 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Api(tags = {"Lumino Hub Connection Resource"})
 @RestController
-@RequestMapping(ControllerConstants.API_V1_VERSION_PATH + "/luminoHubConnection")
+@RequestMapping(ControllerConstants.API_V1_VERSION_PATH + LuminoHubConnectionController.BASE_CONTROLLER_PATH)
 public class LuminoHubConnectionController {
+
+    public static final String BASE_CONTROLLER_PATH = "/luminoHubConnection";
 
     @Autowired
     private LuminoHubManager luminoHubManager;
@@ -25,13 +28,13 @@ public class LuminoHubConnectionController {
     @ApiOperation(value = "Register a new intent to connect to a Lumino Hub, and returns the url of the most appropriate one")
     @PostMapping
     public ResponseEntity<LuminoHubDTO> register() {
-        String hubUrl = luminoHubManager.addConnectionAndGetUrl();
-        return ResponseEntity.accepted().body(new LuminoHubDTO(hubUrl));
+        LuminoHubDTO hubDto = luminoHubManager.addConnectionAndGetUrl();
+        return ResponseEntity.ok(hubDto);
     }
 
     @ExceptionHandler(MaxConnectionException.class)
     public ResponseEntity<Void> handle(MaxConnectionException e) {
-        return ResponseEntity.unprocessableEntity().build();
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/exceptions/MaxConnectionException.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/exceptions/MaxConnectionException.java
@@ -1,0 +1,16 @@
+package org.rif.lumino.explorer.exceptions;
+
+public class MaxConnectionException extends RuntimeException
+{
+
+  public MaxConnectionException(String message) {
+    super(message);
+  }
+
+  public MaxConnectionException() {
+  }
+
+  public MaxConnectionException(Throwable throwable) {
+    super(throwable);
+  }
+}

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/exceptions/NotFoundException.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/exceptions/NotFoundException.java
@@ -1,0 +1,16 @@
+package org.rif.lumino.explorer.exceptions;
+
+public class NotFoundException extends RuntimeException
+{
+
+  public NotFoundException(String message) {
+    super(message);
+  }
+
+  public NotFoundException() {
+  }
+
+  public NotFoundException(Throwable throwable) {
+    super(throwable);
+  }
+}

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/managers/LuminoHubManager.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/managers/LuminoHubManager.java
@@ -5,6 +5,7 @@ import org.rif.lumino.explorer.boot.configuration.properties.LuminoHubProperties
 import org.rif.lumino.explorer.exceptions.MaxConnectionException;
 import org.rif.lumino.explorer.exceptions.NotFoundException;
 import org.rif.lumino.explorer.models.documents.LuminoHub;
+import org.rif.lumino.explorer.models.dto.LuminoHubDTO;
 import org.rif.lumino.explorer.repositories.LuminoHubRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -35,11 +36,11 @@ public class LuminoHubManager {
    * and increases it by one.
    * @return url of the {@link org.rif.lumino.explorer.models.documents.LuminoHub}
    */
-  public String addConnectionAndGetUrl() {
+  public LuminoHubDTO addConnectionAndGetUrl() {
     LuminoHub hub = luminoNodeRepository.findFirstByOrderByConnectionCount()
             .orElseThrow(() -> new NotFoundException("There aren't  Lumino Hub nodes registered in the Explorer"));
     addConnection(hub);
-    return hub.getUrl();
+    return new LuminoHubDTO(hub.getUrl());
   }
 
   private void addConnection(LuminoHub hub) {

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/managers/LuminoHubManager.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/managers/LuminoHubManager.java
@@ -1,18 +1,15 @@
 package org.rif.lumino.explorer.managers;
 
-import com.sun.org.apache.bcel.internal.generic.LUSHR;
 import org.rif.lumino.explorer.boot.configuration.properties.LuminoHubProperties;
 import org.rif.lumino.explorer.exceptions.MaxConnectionException;
 import org.rif.lumino.explorer.exceptions.NotFoundException;
 import org.rif.lumino.explorer.models.documents.LuminoHub;
 import org.rif.lumino.explorer.models.dto.LuminoHubDTO;
 import org.rif.lumino.explorer.repositories.LuminoHubRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -54,8 +51,8 @@ public class LuminoHubManager {
   private void populate() {
     // Populate only if empty
     if (luminoNodeRepository.findAll().isEmpty()) {
-      List<LuminoHub> hubs = luminoHubProperties.getUrls().stream()
-              .map(LuminoHub::new)
+      List<LuminoHub> hubs = luminoHubProperties.getUrls().values().stream()
+              .map(url -> new LuminoHub(url))
               .collect(Collectors.toList());
       luminoNodeRepository.saveAll(hubs);
     }

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/managers/LuminoHubManager.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/managers/LuminoHubManager.java
@@ -1,0 +1,62 @@
+package org.rif.lumino.explorer.managers;
+
+import com.sun.org.apache.bcel.internal.generic.LUSHR;
+import org.rif.lumino.explorer.boot.configuration.properties.LuminoHubProperties;
+import org.rif.lumino.explorer.exceptions.MaxConnectionException;
+import org.rif.lumino.explorer.exceptions.NotFoundException;
+import org.rif.lumino.explorer.models.documents.LuminoHub;
+import org.rif.lumino.explorer.repositories.LuminoHubRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@Service
+public class LuminoHubManager {
+
+  private final LuminoHubRepository luminoNodeRepository;
+
+  private final LuminoHubProperties luminoHubProperties;
+
+  public LuminoHubManager(LuminoHubRepository luminoNodeRepository, LuminoHubProperties luminoHubProperties) {
+    this.luminoNodeRepository = luminoNodeRepository;
+    this.luminoHubProperties = luminoHubProperties;
+    populate();
+  }
+
+
+  /**
+   *
+   * Retrieves the url of the {@link org.rif.lumino.explorer.models.documents.LuminoHub} with the least connection count
+   * and increases it by one.
+   * @return url of the {@link org.rif.lumino.explorer.models.documents.LuminoHub}
+   */
+  public String addConnectionAndGetUrl() {
+    LuminoHub hub = luminoNodeRepository.findFirstByOrderByConnectionCount()
+            .orElseThrow(() -> new NotFoundException("There aren't  Lumino Hub nodes registered in the Explorer"));
+    addConnection(hub);
+    return hub.getUrl();
+  }
+
+  private void addConnection(LuminoHub hub) {
+    if (hub.getConnectionCount() >= luminoHubProperties.getMaxConnections()) {
+      throw new MaxConnectionException("There isn't any Lumino Hub node with free connection slots");
+    }
+    hub.increaseConnectionCount();
+    luminoNodeRepository.save(hub);
+  }
+
+  private void populate() {
+    // Populate only if empty
+    if (luminoNodeRepository.findAll().isEmpty()) {
+      List<LuminoHub> hubs = luminoHubProperties.getUrls().stream()
+              .map(LuminoHub::new)
+              .collect(Collectors.toList());
+      luminoNodeRepository.saveAll(hubs);
+    }
+  }
+}

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/documents/LuminoHub.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/documents/LuminoHub.java
@@ -23,6 +23,11 @@ public class LuminoHub {
         this.connectionCount = 0;
     }
 
+    public LuminoHub(String url, int connectionCount) {
+        this.url = url;
+        this.connectionCount = connectionCount;
+    }
+
     public String getId() {
         return id;
     }

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/documents/LuminoHub.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/documents/LuminoHub.java
@@ -1,0 +1,53 @@
+package org.rif.lumino.explorer.models.documents;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("lumino_hub")
+public class LuminoHub {
+
+    public static final int MAX_CONNECTIONS = 50;
+
+    @Id
+    private String id;
+
+    private String url;
+
+    private Integer connectionCount;
+
+    public LuminoHub() {
+    }
+
+    public LuminoHub(String url) {
+        this.url = url;
+        this.connectionCount = 0;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Integer getConnectionCount() {
+        return connectionCount;
+    }
+
+    public void setConnectionCount(Integer connectionCount) {
+        this.connectionCount = connectionCount;
+    }
+
+    public void increaseConnectionCount() {
+        connectionCount++;
+    }
+}

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/documents/LuminoHub.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/documents/LuminoHub.java
@@ -6,8 +6,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document("lumino_hub")
 public class LuminoHub {
 
-    public static final int MAX_CONNECTIONS = 50;
-
     @Id
     private String id;
 

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/dto/LuminoHubDTO.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/models/dto/LuminoHubDTO.java
@@ -1,0 +1,32 @@
+package org.rif.lumino.explorer.models.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "All details about the Lumino Hub. ")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LuminoHubDTO {
+
+    public LuminoHubDTO() {
+    }
+
+    public LuminoHubDTO(String url) {
+        this.url = url;
+    }
+
+    @ApiModelProperty(notes = "The Lumino Hub url")
+    @JsonProperty("url")
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/repositories/LuminoHubRepository.java
+++ b/lumino-explorer-api/src/main/java/org/rif/lumino/explorer/repositories/LuminoHubRepository.java
@@ -1,0 +1,12 @@
+package org.rif.lumino.explorer.repositories;
+
+import org.rif.lumino.explorer.models.documents.LuminoHub;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.Optional;
+
+public interface LuminoHubRepository extends MongoRepository<LuminoHub, String> {
+
+    Optional<LuminoHub> findFirstByOrderByConnectionCount();
+}

--- a/lumino-explorer-api/src/main/resources/application-dev.properties
+++ b/lumino-explorer-api/src/main/resources/application-dev.properties
@@ -2,7 +2,7 @@
 
 lumino.explorer.api.profile=dev
 rsk.blockchain.endpoint=http://localhost:4444
-lumino.contract.tokenNetworkRegistry=0x59eC7Ced1e1ee2e4ccC74F197fB680D8f9426B96
+lumino.contract.tokenNetworkRegistry=0xaf6Ef1ca196D4AEB14335929Fe3889945B11b021
 
 # Contract org.rif.lumino.explorer.events
 lumino.contracts.openChannelEvent=ChannelOpened
@@ -20,3 +20,7 @@ lumino.explorer.api.account.file=UTC--2019-04-19T15-07-00.568000000Z--034000b5f2
 # Lumino Mongo databse configuration
 lumino.explorer.api.mongo.databasename=lumino_explorer
 lumino.explorer.api.mongo.databasehost=localhost
+
+lumino.explorer.hub.maxConnections=50
+lumino.explorer.hub.urls[0]=http://localhost:1234
+lumino.explorer.hub.urls[1]=http://localhost:1235

--- a/lumino-explorer-api/src/main/resources/application-dev.properties
+++ b/lumino-explorer-api/src/main/resources/application-dev.properties
@@ -22,5 +22,5 @@ lumino.explorer.api.mongo.databasename=lumino_explorer
 lumino.explorer.api.mongo.databasehost=localhost
 
 lumino.explorer.hub.maxConnections=50
-lumino.explorer.hub.urls[0]=http://localhost:1234
-lumino.explorer.hub.urls[1]=http://localhost:1235
+lumino.explorer.hub.urls.test1=http://localhost:1234
+lumino.explorer.hub.urls.test2=http://localhost:1235

--- a/lumino-explorer-api/src/main/resources/application.properties
+++ b/lumino-explorer-api/src/main/resources/application.properties
@@ -1,2 +1,23 @@
-# Start up config
-spring.application.name= "Lumino Explorer API"
+lumino.explorer.api.profile=dev
+rsk.blockchain.endpoint=http://localhost:4444
+lumino.contract.tokenNetworkRegistry=0xbf3885dB740EDEd8213d0DB1c8c2728318f8fa6D
+# Contract org.rif.lumino.explorer.events
+lumino.contracts.openChannelEvent=ChannelOpened
+lumino.contracts.closeChannelEvent=ChannelClosed
+lumino.contracts.settleChannelEvent=ChannelSettled
+lumino.contracts.tokenNetworkCreatedEvent=TokenNetworkCreated
+
+# Block processing
+lumino.explorer.eventsBlockTolerance=10
+
+# Rsk account
+lumino.explorer.api.account.paassword=Z&VT=JRSAQAsMYgSXaCEMf!S7vXaDPfY+SW^aGC4TCATUTjExDb2+=GC7+fux88LdGtR!^m-v4dtX2_*2?9@E$7B7f!RCExn&4R9$GMHxK5vrk&qrp8aZ5Z4GzWPP5@vnffKpXU*2evJm!GtDCN-@BWZ-V*6EMeQ*3Rc=y-gbWFUGGm4+7y2j3fs@mxT$kSe48as-aTZ?BdtMUNgH4tJzeF2%hsy5$M@ELY86Z9dfLWWjq!Up-atxPr!Wt&3a2LZ
+lumino.explorer.api.account.file=UTC--2019-04-19T15-07-00.568000000Z--034000b5f2862d114e4b3474f79fc64aad0cb742.json
+
+# Lumino Mongo databse configuration
+lumino.explorer.api.mongo.databasename=lumino_explorer
+lumino.explorer.api.mongo.databasehost=localhost
+
+lumino.explorer.hub.maxConnections=50
+lumino.explorer.hub.urls[0]=http://localhost:1234
+lumino.explorer.hub.urls[1]=http://localhost:1235

--- a/lumino-explorer-api/src/main/resources/application.properties
+++ b/lumino-explorer-api/src/main/resources/application.properties
@@ -19,5 +19,5 @@ lumino.explorer.api.mongo.databasename=lumino_explorer
 lumino.explorer.api.mongo.databasehost=localhost
 
 lumino.explorer.hub.maxConnections=50
-lumino.explorer.hub.urls[0]=http://localhost:1234
-lumino.explorer.hub.urls[1]=http://localhost:1235
+lumino.explorer.hub.urls.test1=http://localhost:1234
+lumino.explorer.hub.urls.test2=http://localhost:1235

--- a/lumino-explorer-api/src/main/resources/logback-spring.xml
+++ b/lumino-explorer-api/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="LOGS" value="/logs" />
+    <property name="LOGS" value="~/.logs" />
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>%black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable</Pattern>

--- a/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/controllers/ChannelControllerTest.java
+++ b/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/controllers/ChannelControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@WebMvcTest(controllers = ChannelController.class)
+    @WebMvcTest(controllers = ChannelController.class)
 public class ChannelControllerTest {
 
     private static final String CHANNEL_ENDPOINT = ControllerConstants.API_V1_VERSION_PATH + "/" + ChannelController.BASE_CONTROLLER_PATH;

--- a/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/controllers/LuminoHubConnectionControllerTest.java
+++ b/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/controllers/LuminoHubConnectionControllerTest.java
@@ -1,0 +1,64 @@
+package org.rif.lumino.explorer.controllers;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.rif.lumino.explorer.constants.ControllerConstants;
+import org.rif.lumino.explorer.exceptions.MaxConnectionException;
+import org.rif.lumino.explorer.exceptions.NotFoundException;
+import org.rif.lumino.explorer.managers.LuminoHubManager;
+import org.rif.lumino.explorer.models.dto.LuminoHubDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(controllers = LuminoHubConnectionController.class)
+public class LuminoHubConnectionControllerTest {
+
+    private static final String HUB_CONN_ENDPOINT = ControllerConstants.API_V1_VERSION_PATH + "/" + LuminoHubConnectionController.BASE_CONTROLLER_PATH;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LuminoHubManager luminoHubManager;
+
+    @Test
+    public void returnsUrl() throws Exception {
+        final String expectedUrl = "http://localhost:1234";
+        Mockito.when(luminoHubManager.addConnectionAndGetUrl()).thenReturn(new LuminoHubDTO("http://localhost:1234"));
+        mockMvc.perform(MockMvcRequestBuilders.post(HUB_CONN_ENDPOINT))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.url")
+                        .value(Matchers.equalTo(expectedUrl)));
+        Mockito.verify(luminoHubManager).addConnectionAndGetUrl();
+        Mockito.verifyNoMoreInteractions(luminoHubManager);
+    }
+
+    @Test
+    public void NotFoundWhenNotFoundException() throws Exception {
+        Mockito.when(luminoHubManager.addConnectionAndGetUrl()).thenThrow(new NotFoundException());
+        mockMvc.perform(MockMvcRequestBuilders.post(HUB_CONN_ENDPOINT))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+        Mockito.verify(luminoHubManager).addConnectionAndGetUrl();
+        Mockito.verifyNoMoreInteractions(luminoHubManager);
+
+    }
+
+    @Test
+    public void ConflictWhenMaxConnectionException() throws Exception {
+        Mockito.when(luminoHubManager.addConnectionAndGetUrl()).thenThrow(new MaxConnectionException());
+        mockMvc.perform(MockMvcRequestBuilders.post(HUB_CONN_ENDPOINT))
+                .andExpect(MockMvcResultMatchers.status().isConflict());
+        Mockito.verify(luminoHubManager).addConnectionAndGetUrl();
+        Mockito.verifyNoMoreInteractions(luminoHubManager);
+
+    }
+}

--- a/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/documents/CreateJobMetadata.java
+++ b/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/documents/CreateJobMetadata.java
@@ -5,15 +5,17 @@ import org.rif.lumino.explorer.models.documents.EventJobMetadata;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.rif.lumino.explorer.repositories.EventJobDataRepository;
 
 import java.math.BigInteger;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class)
-  public class CreateJobMetadata {
+@DataMongoTest
+public class CreateJobMetadata {
 
   @Autowired EventJobDataRepository eventJobDataRepository;
 

--- a/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/managers/LuminoHubManagerTest.java
+++ b/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/managers/LuminoHubManagerTest.java
@@ -1,30 +1,24 @@
 package org.rif.lumino.explorer.managers;
 
-import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.Condition;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.rif.lumino.explorer.boot.configuration.properties.LuminoHubProperties;
-import org.rif.lumino.explorer.controllers.LuminoHubConnectionController;
 import org.rif.lumino.explorer.exceptions.MaxConnectionException;
 import org.rif.lumino.explorer.exceptions.NotFoundException;
 import org.rif.lumino.explorer.models.documents.LuminoHub;
 import org.rif.lumino.explorer.models.dto.LuminoHubDTO;
 import org.rif.lumino.explorer.repositories.LuminoHubRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @RunWith(SpringRunner.class)
@@ -52,8 +46,11 @@ public class LuminoHubManagerTest {
     @Before
     public void init() {
         Mockito.when(luminoHubProperties.getMaxConnections()).thenReturn(50);
+        Map<String, String> config = new HashMap<>();
+        config.put("test1", "http://localhost:1234");
+        config.put("test2", "http://localhost:1235");
         Mockito.when(luminoHubProperties.getUrls())
-                .thenReturn(Arrays.asList("http://localhost:1234","http://localhost:1235"));
+                .thenReturn(config);
 
     }
 

--- a/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/managers/LuminoHubManagerTest.java
+++ b/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/managers/LuminoHubManagerTest.java
@@ -1,0 +1,106 @@
+package org.rif.lumino.explorer.managers;
+
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.rif.lumino.explorer.boot.configuration.properties.LuminoHubProperties;
+import org.rif.lumino.explorer.controllers.LuminoHubConnectionController;
+import org.rif.lumino.explorer.exceptions.MaxConnectionException;
+import org.rif.lumino.explorer.exceptions.NotFoundException;
+import org.rif.lumino.explorer.models.documents.LuminoHub;
+import org.rif.lumino.explorer.models.dto.LuminoHubDTO;
+import org.rif.lumino.explorer.repositories.LuminoHubRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@RunWith(SpringRunner.class)
+public class LuminoHubManagerTest {
+
+    @TestConfiguration
+    public static class LuminoHubManagerTestConfiguration {
+        @Bean
+        public LuminoHubManager luminoHubManager(
+                LuminoHubRepository luminoHubRepository,
+                LuminoHubProperties luminoHubProperties) {
+            return new LuminoHubManager(luminoHubRepository, luminoHubProperties);
+        }
+    }
+
+    @Autowired
+    private LuminoHubManager luminoHubManager;
+
+    @MockBean
+    private LuminoHubRepository luminoHubRepository;
+
+    @MockBean
+    private LuminoHubProperties luminoHubProperties;
+
+    @Before
+    public void init() {
+        Mockito.when(luminoHubProperties.getMaxConnections()).thenReturn(50);
+        Mockito.when(luminoHubProperties.getUrls())
+                .thenReturn(Arrays.asList("http://localhost:1234","http://localhost:1235"));
+
+    }
+
+    @Test
+    public void registersAndReturnsUrl() {
+        final LuminoHub hub = new LuminoHub("http://localhost:1234");
+        final int initialCount = hub.getConnectionCount();
+        final LuminoHubDTO expected =  new LuminoHubDTO(hub.getUrl());
+
+        Mockito.when(luminoHubRepository.findFirstByOrderByConnectionCount())
+                .thenReturn(Optional.of(hub));
+
+        LuminoHubDTO actual = luminoHubManager.addConnectionAndGetUrl();
+
+        Assertions.assertThat(actual).isNotNull().as("Result should not be null");
+        Assertions.assertThat(actual.getUrl()).isEqualTo(expected.getUrl()).as("Url should be %s", hub.getUrl());
+        Assertions.assertThat(hub.getConnectionCount()).isEqualTo(initialCount + 1).as("Connection count should have increased");
+
+        Mockito.verify(luminoHubRepository).findFirstByOrderByConnectionCount();
+        Mockito.verify(luminoHubProperties).getMaxConnections();
+        Mockito.verify(luminoHubRepository).save(hub);
+    }
+
+    @Test
+    public void notFoundWhenEmptyRepository() {
+        final LuminoHub hub = new LuminoHub("http://localhost:1234");
+
+        Mockito.when(luminoHubRepository.findFirstByOrderByConnectionCount())
+                .thenReturn(Optional.empty());
+
+        Assertions.assertThatThrownBy(() -> luminoHubManager.addConnectionAndGetUrl())
+                .isInstanceOf(NotFoundException.class);
+        Mockito.verify(luminoHubRepository).findFirstByOrderByConnectionCount();
+    }
+
+    @Test
+    public void maxConnectionWhenNoConnectionSlotsLeft() {
+        final LuminoHub hub = new LuminoHub("http://localhost:1234");
+        hub.setConnectionCount(50);
+
+        Mockito.when(luminoHubRepository.findFirstByOrderByConnectionCount())
+                .thenReturn(Optional.of(hub));
+
+        Assertions.assertThatThrownBy(() -> luminoHubManager.addConnectionAndGetUrl())
+                .isInstanceOf(MaxConnectionException.class);
+
+        Mockito.verify(luminoHubRepository).findFirstByOrderByConnectionCount();
+        Mockito.verify(luminoHubProperties).getMaxConnections();
+    }
+}

--- a/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/repositories/LuminoHubRepositoryTest.java
+++ b/lumino-explorer-api/src/test/java/org/rif/lumino/explorer/repositories/LuminoHubRepositoryTest.java
@@ -1,0 +1,38 @@
+package org.rif.lumino.explorer.repositories;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rif.lumino.explorer.models.documents.LuminoHub;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@RunWith(SpringRunner.class)
+@DataMongoTest
+public class LuminoHubRepositoryTest {
+    @Autowired
+    private LuminoHubRepository luminoHubRepository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Test
+    public void retrievesMinimum() {
+        mongoTemplate.getDb().drop();
+        mongoTemplate.insert(Arrays.asList(
+                new LuminoHub("http://localhost:4321", 33),
+                new LuminoHub("http://localhost:4322", 11),
+                new LuminoHub("http://localhost:4323", 22)), LuminoHub.class);
+        Optional<LuminoHub> actual = luminoHubRepository.findFirstByOrderByConnectionCount();
+
+        Assertions.assertThat(actual).isPresent();
+        Assertions.assertThat(actual.get().getUrl()).isEqualTo("http://localhost:4322");
+    }
+
+}


### PR DESCRIPTION
Changes:

- Add load balancing endpoint and its documentation

#### ```POST /luminoHubConnection ```  
This endpoint adds a new connection to the hub 
with the minimum number of connections, increases the count by 1 
and returns the Hub's url.

- **returns:**
   * **200 OK**: If there is at least on Hub with available connections.  
   Body:  
   ``` { "url": "Hub's url" } ```
   * **404 NOT FOUND**: If there isn't any registered Hub.
   * **409 CONFLICT**: If there isn't a Hub with available connections. 